### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "An experimental driver crate for the DW3XXX series of UWB ranging modules."
 readme = "README.md"
-repository = "http://github.com/wtoll/dw3xxx"
-documentation = "http://docs.rs/dw3xxx"
+repository = "https://github.com/wtoll/dw3xxx"
+documentation = "https://docs.rs/dw3xxx"
 keywords = ["driver", "embedded-hal", "uwb"]
 categories = ["embedded", "no-std", "hardware-support"]
 


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97